### PR TITLE
[#13] TanStack/React-Query 세팅

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import QueryProvider from '@/components/QueryProvider';
+
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
 import { Toaster } from 'react-hot-toast';
@@ -11,7 +13,7 @@ function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko">
       <body>
-        {children}
+        <QueryProvider>{children}</QueryProvider>
         <Toaster containerStyle={{ fontSize: '16px' }} />
       </body>
     </html>

--- a/src/components/QueryProvider/index.tsx
+++ b/src/components/QueryProvider/index.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+import { ReactNode, useState } from 'react';
+
+function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 20 * 1000,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+
+export default QueryProvider;


### PR DESCRIPTION
## 👊🏻 작업 내용
- [x] TanStack/React-Query 세팅

## 🏌🏻 리뷰 포인트
- Provider를 `layout.tsx`에서 정의하지 않고 컴포넌트로 만들었습니다.
- 그리고 컴포넌트를 다음과 같이 `QueryProvider/index.tsx` 구조로 했는데 다른 분들 의견이 궁금합니다.
- 어제 깃허브 구경하다가 발견한 구조인데 생각보다 정리가 잘된다는 느낌을 받아서 일단은 적용 해봤습니다. <a href="https://github.com/depromeet/toks-web/tree/dev/src/common/components">참고링크</a>

## 🧘🏻 기타 사항
- staleTime에 대해서 궁금하신 분들은 해당 링크를 보시면 이해가 되실 겁니다. <a href="https://i-ten.tistory.com/315#toc-staleTime">참고링크</a>
- 20초로 설정한 이유는 <a href="https://tkdodo.eu/blog/react-query-as-a-state-manager#customize-staletime">react query maintainer의 블로그</a>에서 나와 있어서 설정 했습니다.
- 해당 블로그에서 20초 정도면 충분히 중복 호출을 방지할 수 있다고 합니다.
<img width="800" height="auto" alt="스크린샷 2024-01-17 오전 10 29 49" src="https://github.com/GymHubCommunity/GymHub-FE/assets/49686619/991c4545-be7b-4da1-b251-e485c9f5cea5">

