### PR TITLE
[#19] SonarCloud 세팅

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,24 @@
+name: SonarCloud Code Analyze
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+          

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=GymHubCommunity_GymHub-FE
+sonar.organization=gymhubcommunity

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: 'GymHub',
 };
 
-function RootLayout({ children }: { children: ReactNode }) {
+function RootLayout({ children }: { children: Readonly<ReactNode> } ) {
   return (
     <html lang="ko">
       <body>


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] SonarCloud

## 🏌🏻 리뷰 포인트

**sonar cloud**를 적용하였습니다

sonar cloud는 **정적 코드 분석기**로 **코드의 일관성과 유지보수성, 안정성 및 보안**을 체크하는 역할을 해요

대시보드에서 코드 지표를 통해 **코드 퀄리티 관리**가 가능하고 작은 실수 등 **Code Smells를 체크**해주어 저희가 코드 리뷰를 하더라도 놓칠 수 있는 부분을 sonar cloud가 잡아준다는 점에서 이를 도입하게 되었습니다!
(한 명의 코드리뷰어가 생긴 기분 ㅎㅎ😆)

sonar cloud는 기본적으로 Automatic Analysis 설정이라 따로 **github actions**을 적용해 sonar cloud의 체크 주기를 조정하였습니다

pr의 링크를 클릭하시면 아래와 같이 확인하실 수 있습니다!

<img width="50%" alt="스크린샷 2024-01-19 오후 6 46 29" src="https://github.com/GymHubCommunity/GymHub-FE/assets/63100352/6fcb9cbc-fb39-4457-9d47-709ffa5361f1">

## 🧘🏻 기타 사항

pr에 이쁘게 나오면 좋을 것 같아서 pr 데코레이션도 찾아봤는데 [다음과 같은](https://github.com/jhipster/jhipster-lite/issues/6133) 이유로 sonarcloud는 적용이 안 되는 것 같더라구요

sonarcloud pr 메세지에 써있는 Kudos는 감사합니다 라는 뜻이라고 하네용 ㅎㅎ
