### PR TITLE
[#50] git Actions CI 대소문 구분 옵션 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Configure Git
+        run: git config core.ignorecase false
+
       - name: Check Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] git Actions CI 대소문 구분 옵션 설정

## 🏌🏻 리뷰 포인트
대소문자 구분 할 수 있도록 옵션 설정 해놓았습니다.

## 🧘🏻 기타 사항


