### PR TITLE
[#262] 글 작성자만 게시글 삭제 및 수정 권한 기능 추가

### DIFF
--- a/src/app/api/auth/callback/[...provider]/page.tsx
+++ b/src/app/api/auth/callback/[...provider]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { postOAuth } from '@/apis/oAuth';
 import Loading from '@/components/atoms/Loading';
+import useLoginUser from '@/hooks/useLoginUser';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
@@ -9,6 +10,7 @@ function CallbackOAuth(social: any) {
   const router = useRouter();
   const params = useSearchParams();
   const authCode = params.get('code');
+  const [, setUser] = useLoginUser();
 
   useEffect(() => {
     const handleLogin = async () => {
@@ -16,6 +18,7 @@ function CallbackOAuth(social: any) {
         try {
           const data = await postOAuth(social.params.provider[0], authCode);
           localStorage.setItem('accessToken', data.data.accessToken);
+          setUser(data.data.userInfo);
 
           if (!data.data.requiredAdditionalInfo) {
             router.push('/');

--- a/src/components/molecules/PostProfile/index.tsx
+++ b/src/components/molecules/PostProfile/index.tsx
@@ -5,6 +5,7 @@ import Text from '@/components/atoms/Text';
 import styles from '@/components/molecules/PostProfile/PostProfile.module.scss';
 import { WriterInfoProps } from '@/types/GetPost';
 import Link from 'next/link';
+import useLoginUser from '@/hooks/useLoginUser';
 
 interface PostProfileProps {
   type: 'default' | 'exercised';
@@ -13,6 +14,7 @@ interface PostProfileProps {
 }
 
 function PostProfile({ type, postProfile, postId }: PostProfileProps) {
+  const [loginUser] = useLoginUser();
   if (!postProfile) return;
   const memberId = postProfile.writerId;
 
@@ -27,7 +29,7 @@ function PostProfile({ type, postProfile, postId }: PostProfileProps) {
           )}
         </div>
       </Link>
-      <ToggleMenu type="post" id={postId} />
+      {loginUser?.id === memberId ? <ToggleMenu type="post" id={postId} /> : ''}
     </div>
   );
 }

--- a/src/components/molecules/SettingArticle/index.tsx
+++ b/src/components/molecules/SettingArticle/index.tsx
@@ -1,6 +1,7 @@
 import { postLogout } from '@/apis/oAuth';
 import ToggleButton from '@/components/atoms/Button/ToggleButton';
 import styles from '@/components/molecules/SettingArticle/SettingArticle.module.scss';
+import useLoginUser from '@/hooks/useLoginUser';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
@@ -10,6 +11,7 @@ interface SettingArticleProps {
 }
 
 function SettingArticle({ type, children }: SettingArticleProps) {
+  const [, initUser] = useLoginUser();
   switch (type) {
     case 'profileToggle':
       return (
@@ -24,7 +26,10 @@ function SettingArticle({ type, children }: SettingArticleProps) {
           <Link
             href="/signin"
             className={styles.settingName}
-            onClick={() => postLogout()}
+            onClick={() => {
+              initUser(null);
+              postLogout();
+            }}
           >
             로그아웃
           </Link>

--- a/src/hooks/useLoginUser.ts
+++ b/src/hooks/useLoginUser.ts
@@ -23,7 +23,8 @@ function useLoginUser(): [
   const [loginUser, setLoginUser] = useAtom(loginUserAtom);
 
   const initUser = () => {
-    setLoginUser({ email: '', id: 0, nickname: '', profileUrl: '' });
+    if (!loginUser) return;
+    setLoginUser(null);
   };
 
   const setUser = (userInfo: LoginUserProps | null) => {

--- a/src/hooks/useLoginUser.ts
+++ b/src/hooks/useLoginUser.ts
@@ -1,0 +1,36 @@
+import { useAtom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+export interface LoginUserProps {
+  email: string;
+  id: number;
+  nickname: string;
+  profileUrl: string;
+}
+
+const loginUserAtom = atomWithStorage<LoginUserProps | null>('loginUser', {
+  email: '',
+  id: 0,
+  nickname: '',
+  profileUrl: '',
+});
+
+function useLoginUser(): [
+  LoginUserProps | null,
+  (userInfo: LoginUserProps | null) => void,
+  () => void,
+] {
+  const [loginUser, setLoginUser] = useAtom(loginUserAtom);
+
+  const initUser = () => {
+    setLoginUser({ email: '', id: 0, nickname: '', profileUrl: '' });
+  };
+
+  const setUser = (userInfo: LoginUserProps | null) => {
+    setLoginUser(userInfo);
+  };
+
+  return [loginUser, setUser, initUser];
+}
+
+export default useLoginUser;


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 로그인 유저 정보 전역객체 
- [x] 게시글 작성자 글에만 토글 버튼 보이도록 설정

## 🏌🏻 리뷰 포인트
- 로그인한 유저정보에 대해 jotai를 활용해 로컬스토리지에서 전역객체로 관리합니다.
- 게시글 작성자 이외에 글에 토글버튼을 숨김 처리 하였습니다.
- 공통으로 처리되어서 피드 페이지, 마이페이지 , 검색페이지 등에서 적용됩니다.


## 🧘🏻 기타 사항
![로그인 계정 기준 게시물 수정권한 부여](https://github.com/GymHubCommunity/GymHub-FE/assets/72487120/dbb3d082-f03f-4fe7-9a96-e754c0004c9d)

